### PR TITLE
changed syntax

### DIFF
--- a/src/common.jl
+++ b/src/common.jl
@@ -1,19 +1,19 @@
 export init, train
 
 "abstract Hyperparameters"
-abstract AbstractHyperparam;
+abstract type AbstractHyperparam end;
 
 "Abstract Model Data Object"
-abstract AbstractModelData;
+abstract type AbstractModelData end;
 
 "Abstract Model Buffer Object"
-abstract AbstractModelBuffer;
+abstract type AbstractModelBuffer end;
 
-abstract ModelType;
+abstract type ModelType end;
 
-abstract InitialisationType;
+abstract type InitialisationType end;
 
-abstract PosteriorInference;
+abstract type PosteriorInference end;
 
 function init(X, model::ModelType, init::InitialisationType)
   throw(ErrorException("Initialisation $(typeof(init)) for $(typeof(model)) using $(typeof(X)) is not available."))

--- a/src/distributions.jl
+++ b/src/distributions.jl
@@ -1,17 +1,17 @@
 export WishartGaussian, GaussianDiagonal, DirichletMultinomial, GammaNormal, NormalNormal, BetaBernoulli, ConjugatePostDistribution
 
-abstract ConjugatePostDistribution
+abstract type ConjugatePostDistribution end
 
-abstract UnivariateConjugatePostDistribution <: ConjugatePostDistribution
-abstract DiscreteUnivariateConjugatePostDistribution <: UnivariateConjugatePostDistribution
-abstract ContinuousUnivariateConjugatePostDistribution <: UnivariateConjugatePostDistribution
+abstract type UnivariateConjugatePostDistribution <: ConjugatePostDistribution end
+abstract type DiscreteUnivariateConjugatePostDistribution <: UnivariateConjugatePostDistribution end
+abstract type ContinuousUnivariateConjugatePostDistribution <: UnivariateConjugatePostDistribution end
 
-abstract MultivariateConjugatePostDistribution <: ConjugatePostDistribution
-abstract DiscreteMultivariateConjugatePostDistribution <: MultivariateConjugatePostDistribution
-abstract ContinuousMultivariateConjugatePostDistribution <: MultivariateConjugatePostDistribution
+abstract type MultivariateConjugatePostDistribution <: ConjugatePostDistribution end
+abstract type DiscreteMultivariateConjugatePostDistribution <: MultivariateConjugatePostDistribution end
+abstract type ContinuousMultivariateConjugatePostDistribution <: MultivariateConjugatePostDistribution end
 
 # Gaussian with Normal Inverse Wishart Prior
-type WishartGaussian <: ContinuousMultivariateConjugatePostDistribution
+mutable struct WishartGaussian <: ContinuousMultivariateConjugatePostDistribution
 
     D::Int
 
@@ -36,12 +36,12 @@ type WishartGaussian <: ContinuousMultivariateConjugatePostDistribution
 end
 
 # Normal with Gamma prior
-type GammaNormal <: ContinuousUnivariateConjugatePostDistribution
+mutable struct GammaNormal <: ContinuousUnivariateConjugatePostDistribution
 
 	# sufficient statistics
 	n::Int
 	sums::Float64
-  ssums::Float64
+    ssums::Float64
 
 	# model parameters
 	μ0::Float64
@@ -56,12 +56,12 @@ type GammaNormal <: ContinuousUnivariateConjugatePostDistribution
 end
 
 # Normal with Normal prior
-type NormalNormal <: ContinuousUnivariateConjugatePostDistribution
+mutable struct NormalNormal <: ContinuousUnivariateConjugatePostDistribution
 
 	# sufficient statistics
 	n::Int
 	sums::Float64
-  ssums::Float64
+    ssums::Float64
 
 	# model parameters
 	μ0::Float64
@@ -74,19 +74,20 @@ type NormalNormal <: ContinuousUnivariateConjugatePostDistribution
 end
 
 # Gaussian with Diagonal Covariance
-type GaussianDiagonal{T <: ContinuousUnivariateConjugatePostDistribution} <: ContinuousMultivariateConjugatePostDistribution
+mutable struct GaussianDiagonal{T <: ContinuousUnivariateConjugatePostDistribution} <: ContinuousMultivariateConjugatePostDistribution
 
     # sufficient statistics
     dists::Vector{T}
 
-    function GaussianDiagonal(dists::Vector{T})
-        new(dists)
-    end
+    # isn't the default constructor sufficient here?
+    #function GaussianDiagonal(dists::Vector{T})
+    #    new(dists)
+    #end
 
 end
 
 # Multinomial with Dirichlet Prior
-type DirichletMultinomial <: DiscreteMultivariateConjugatePostDistribution
+mutable struct DirichletMultinomial <: DiscreteMultivariateConjugatePostDistribution
 
     D::Int
 
@@ -109,11 +110,11 @@ type DirichletMultinomial <: DiscreteMultivariateConjugatePostDistribution
 end
 
 # Bernoulli with Beta Prior
-type BetaBernoulli <: DiscreteUnivariateConjugatePostDistribution
+mutable struct BetaBernoulli <: DiscreteUnivariateConjugatePostDistribution
 
 	# sufficient statistics
 	successes::Int
-  n::Int
+    n::Int
 
 	# beta distribution parameters
 	α0::Float64

--- a/src/dpmm.jl
+++ b/src/dpmm.jl
@@ -1,7 +1,7 @@
 export DPMHyperparam, DPMData
 
 "Dirichlet Process Mixture Model Hyperparameters"
-immutable DPMHyperparam <: AbstractHyperparam
+struct DPMHyperparam <: AbstractHyperparam
 
   γ_a::Float64
   γ_b::Float64
@@ -12,7 +12,7 @@ immutable DPMHyperparam <: AbstractHyperparam
 end
 
 "Dirichlet Process Mixture Model Data Object"
-type DPMData <: AbstractModelData
+mutable struct DPMData <: AbstractModelData
 
   # Energy
   energy::Float64
@@ -31,7 +31,7 @@ type DPMData <: AbstractModelData
 
 end
 
-type DPMBuffer <: AbstractModelBuffer
+mutable struct DPMBuffer <: AbstractModelBuffer
 
   # ids used for random access
   ids::Array{Int}
@@ -204,7 +204,7 @@ function gibbs!(B::DPMBuffer)
     end
 
     p[B.K + 1] = logpostpred(B.G0, x)[1] + log( B.alpha / (B.N + B.alpha - 1) )
-    p = exp(p - maximum(p))
+    p = exp.(p - maximum(p))
 
     k = randomindex(p)
 

--- a/src/hdp.jl
+++ b/src/hdp.jl
@@ -1,7 +1,7 @@
 export HDPHyperparam
 
 "Hierarchical Dirichlet Process Mixture Model Hyperparameters"
-immutable HDPHyperparam <: AbstractHyperparam
+struct HDPHyperparam <: AbstractHyperparam
 
   γ_a::Float64
   γ_b::Float64
@@ -15,7 +15,7 @@ immutable HDPHyperparam <: AbstractHyperparam
 end
 
 "Hierarchical Dirichlet Process Mixture Model Data Object"
-type HDPData <: AbstractModelData
+mutable struct HDPData <: AbstractModelData
 
   # Energy
   energy::Float64
@@ -31,7 +31,7 @@ type HDPData <: AbstractModelData
 
 end
 
-type HDPBuffer{T <: Real} <: AbstractModelBuffer
+mutable struct HDPBuffer{T <: Real} <: AbstractModelBuffer
 
   # samples
   X::Vector{Vector{T}}

--- a/src/inference.jl
+++ b/src/inference.jl
@@ -1,6 +1,6 @@
 export Gibbs, SliceSampler
 
-type Gibbs <: PosteriorInference
+mutable struct Gibbs <: PosteriorInference
         burnin::Int
         thinout::Int
         maxiter::Int
@@ -8,7 +8,7 @@ type Gibbs <: PosteriorInference
         Gibbs(; burnin = 0, thinout = 1, maxiter = 100) = new(burnin, thinout, maxiter)
 end
 
-type SliceSampler <: PosteriorInference
+mutable struct SliceSampler <: PosteriorInference
         burnin::Int
         thinout::Int
         maxiter::Int

--- a/src/inits.jl
+++ b/src/inits.jl
@@ -1,19 +1,19 @@
 export PrecomputedInitialisation, RandomInitialisation, KMeansInitialisation, IncrementalInitialisation
 
-type PrecomputedInitialisation <: InitialisationType
+mutable struct PrecomputedInitialisation <: InitialisationType
   Z::Array{Int}
   PrecomputedInitialisation(Z::Array{Int}) = new(Z)
 end
 
-type RandomInitialisation <: InitialisationType
+mutable struct RandomInitialisation <: InitialisationType
   k::Int
   RandomInitialisation(;k = 2) = new(k)
 end
 
-type KMeansInitialisation <: InitialisationType
+mutable struct KMeansInitialisation <: InitialisationType
   k::Int
   maxiterations::Int
   KMeansInitialisation(;k = 2, maxiterations = 1000) = new(k, maxiterations)
 end
 
-type IncrementalInitialisation <: InitialisationType end
+mutable struct IncrementalInitialisation <: InitialisationType end

--- a/src/models.jl
+++ b/src/models.jl
@@ -2,20 +2,20 @@ export DPM, VCM, HDP
 
 # define models
 
-type DPM <: ModelType
+mutable struct DPM <: ModelType
   H::ConjugatePostDistribution
   α::Float64
 
   DPM(H::ConjugatePostDistribution; α = 1.0) = new(H, α)
 end
 
-type VCM <: ModelType
+mutable struct VCM <: ModelType
   α::Float64
 
   VCM(;α = 1.0) = new(α)
 end
 
-type HDP <: ModelType
+mutable struct HDP <: ModelType
   H::ConjugatePostDistribution
   α::Float64
   γ::Float64


### PR DESCRIPTION
Change syntax for `Julia 0.6`.

`immutable` changes to `struct`
`type` changes to `mutable struct`
`abstract` changes to `abstract type ... end`

Please also review, the commenting of the inner constructor in `GaussianDiagonal `, It gave me syntax warning on 0.6.

Note that I had the following Test error both before and after the commit.
```
Test Failed
  Expression: model0.energy < model1.energy
   Evaluated: -4.54650303362464 < -4.585352987271349
ERROR: LoadError: LoadError: There was an error during testing
while loading /Users/jon.alm.eriksen/.julia/v0.6/BayesianNonparametrics/test/dpmTests.jl, in expression starting on line 26
while loading /Users/jon.alm.eriksen/.julia/v0.6/BayesianNonparametrics/test/runtests.jl, in expression starting on line 7
===============================================[ ERROR: BayesianNonparametrics ]================================================

failed process: Process(`/Users/jon.alm.eriksen/opt/julia/usr/bin/julia -Cnative -J/Users/jon.alm.eriksen/opt/julia/usr/lib/julia/sys.dylib --compile=yes --depwarn=yes --check-bounds=yes --code-coverage=none --color=yes --compilecache=yes /Users/jon.alm.eriksen/.julia/v0.6/BayesianNonparametrics/test/runtests.jl`, ProcessExited(1)) [1]

================================================================================================================================
```